### PR TITLE
Enhanced EyePointer Installerにおける目ボーンの解決処理を改善

### DIFF
--- a/Editor/Modules/EnhancedEyePointerInstaller/EyeBonesModifier.cs
+++ b/Editor/Modules/EnhancedEyePointerInstaller/EyeBonesModifier.cs
@@ -44,9 +44,22 @@ namespace KusakaFactory.Zatools.Modules.EnhancedEyePointerInstaller
 
         private static (GameObject LeftEye, GameObject RightEye) LocateEyeBones(GameObject avatarRoot)
         {
+            var avatarDescriptor = avatarRoot.GetComponent<VRCAvatarDescriptor>();
+            if (avatarDescriptor.enableEyeLook)
+            {
+                return LocateEyeBonesFromVRCAvatarDescriptor(avatarDescriptor);
+            }
+
             // TODO: もっと intelligent にする
             var leftEyeTransform = avatarRoot.transform.Find("Armature/Hips/Spine/Chest/Neck/Head/LeftEye");
             var rightEyeTransform = avatarRoot.transform.Find("Armature/Hips/Spine/Chest/Neck/Head/RightEye");
+            return (leftEyeTransform.gameObject, rightEyeTransform.gameObject);
+        }
+
+        private static (GameObject LeftEye, GameObject RightEye) LocateEyeBonesFromVRCAvatarDescriptor(VRCAvatarDescriptor avatarDescriptor)
+        {
+            var leftEyeTransform = avatarDescriptor.customEyeLookSettings.leftEye;
+            var rightEyeTransform = avatarDescriptor.customEyeLookSettings.rightEye;
             return (leftEyeTransform.gameObject, rightEyeTransform.gameObject);
         }
 


### PR DESCRIPTION
ちょっとだけIntelligentにした

## 概要
- 目ボーンの解決時、VRCAvatarDescriptorから目ボーンが取得可能な場合にそちらから取得するよう変更
  - `VRCAvatarDescriptor.enableEyeLook`が`true`の場合にVRCAvatarDescriptorから取得する処理としています
  - 一応メソッド分けてありますが、こちらはお好みで修正いただけると幸いです

## 備考
- 元処理はそのまま残してあります。
  - `VRCAvatarDescriptor.enableEyeLook`が`false`の場合、従来の処理にフォールバックする想定