### PR TITLE
BlendShape 系コンポーネントの NDMF Preview をデフォルト無効にする

### DIFF
--- a/Editor/Ndmf/Core/Ahnb.cs
+++ b/Editor/Ndmf/Core/Ahnb.cs
@@ -142,7 +142,7 @@ namespace KusakaFactory.Zatools.Ndmf.Core
 
             internal static FixedParameters FixFromComponent(Transform defaultDirection, AdHocNormalBending component)
             {
-                var directionSource = component.Direction != null ? defaultDirection : component.transform;
+                var directionSource = component.Direction != null ? component.Direction : defaultDirection;
                 return new FixedParameters()
                 {
                     WorldSpaceForward = directionSource.forward,

--- a/Editor/Ndmf/Preview/AhbsmPreview.cs
+++ b/Editor/Ndmf/Preview/AhbsmPreview.cs
@@ -10,7 +10,7 @@ namespace KusakaFactory.Zatools.Ndmf.Preview
 {
     internal sealed class AhbsmRenderFilter : ZatoolsRenderFilter<AdHocBlendShapeMix>
     {
-        internal AhbsmRenderFilter() : base("Ad-Hoc BlendShape Mix", "ad-hoc-blendshape-mix") { }
+        internal AhbsmRenderFilter() : base("Ad-Hoc BlendShape Mix", "ad-hoc-blendshape-mix", false) { }
 
         internal override ZatoolsRenderFilterNode<AdHocBlendShapeMix> CreateNode() => new AhbsmRenderFilterNode();
     }

--- a/Editor/Ndmf/ZatoolsRenderFilter.cs
+++ b/Editor/Ndmf/ZatoolsRenderFilter.cs
@@ -15,9 +15,9 @@ namespace KusakaFactory.Zatools.Ndmf
     {
         private readonly TogglablePreviewNode _toggleNode;
 
-        protected ZatoolsRenderFilter(string name, string qualifiedName)
+        protected ZatoolsRenderFilter(string name, string qualifiedName, bool initialState = true)
         {
-            _toggleNode = TogglablePreviewNode.Create(() => name, $"org.kb10uy.zatools/{qualifiedName}");
+            _toggleNode = TogglablePreviewNode.Create(() => name, $"org.kb10uy.zatools/{qualifiedName}", initialState);
         }
 
         public IEnumerable<TogglablePreviewNode> GetPreviewControlNodes() => new[] { _toggleNode };


### PR DESCRIPTION
調査の結果 Mesh.AddBlendShapeFrame が信じられないほど遅いことが判明したため。
機能自体は残す。