### PR TITLE
Observe texture content in AhNB preview

### DIFF
--- a/Editor/Ndmf/Preview/AhnbPreview.cs
+++ b/Editor/Ndmf/Preview/AhnbPreview.cs
@@ -48,6 +48,7 @@ namespace KusakaFactory.Zatools.Ndmf.Preview
             foreach (var component in components)
             {
                 if (component.Direction != null) context.Observe(component.Direction, (t) => t.worldToLocalMatrix);
+                if (component.Mask != null) context.Observe(component.Mask, (tm) => (tm.width, tm.height, tm.imageContentsHash));
             }
 
             // プレビュー処理で影響を及ぼすボーンのリストを収集して追加で監視する


### PR DESCRIPTION
こっちでは抜けてた

が、imageContentHash はインポートとベイク以外では更新されない(Unity が計算しない)ので実はこの用途に使うのは微妙かもしれないとのこと
See: https://misskey.niri.la/notes/alhon53u4o