### PR TITLE
EDW で ForwardBase を書かない

### DIFF
--- a/Resources/Embedded/Shaders/EdwWrapper.shader
+++ b/Resources/Embedded/Shaders/EdwWrapper.shader
@@ -6,6 +6,9 @@ Shader "KusakaFactory/Zatools/EdwWrapper"
         Tags { "RenderType"="Opaque" "Queue"="AlphaTest+49" }
         LOD 100
 
+        // Writing depth in ForwardBase pass causes typical RQ problem.
+        // As EyeholeDepthWrapper's concern is only about _CameraDepthTexture, we can simply omit ForwardBase pass.
+        /*
         Pass
         {
             Tags { "LightMode"="ForwardBase" }
@@ -41,6 +44,7 @@ Shader "KusakaFactory/Zatools/EdwWrapper"
             }
             ENDCG
         }
+        */
 
         Pass
         {


### PR DESCRIPTION
CameraDepthTexture は ShadowCaster しか参照しないので ForwardBase で深度を書く必要はない
むしろ顔のエフェクトが 3000 とかで書かれてると RQ 負けして貫通して悪影響