### PR TITLE
Hide EDW's mesh on shader fallback

### DIFF
--- a/Resources/Embedded/Shaders/EdwWrapper.shader
+++ b/Resources/Embedded/Shaders/EdwWrapper.shader
@@ -3,7 +3,7 @@ Shader "KusakaFactory/Zatools/EdwWrapper"
     Properties {}
     SubShader
     {
-        Tags { "RenderType"="Opaque" "Queue"="AlphaTest+49" }
+        Tags { "RenderType"="Opaque" "Queue"="AlphaTest+49" "VRCFallback"="Hidden" }
         LOD 100
 
         // Writing depth in ForwardBase pass causes typical RQ problem.


### PR DESCRIPTION
This PR adds [VRChat's Shader Fallback](https://creators.vrchat.com/avatars/shader-fallback-system/) tag to hide EDW mesh, so that the mesh stays hidden during shader fallback.
  
| Before | After |
| ------- | ------ |
| <img width="342" height="290" alt="before" src="https://github.com/user-attachments/assets/dfc54f85-ee3b-448a-a4be-7b4d4bc947d1" /> |  <img width="342" height="292" alt="after" src="https://github.com/user-attachments/assets/5e730084-6de3-4aa9-a7ee-3427d2b268e6" /> |
