### PR TITLE
Support Separate SkinnedMeshRenderer mode for CDW

### DIFF
--- a/Editor/Ndmf/Core/Cdw.cs
+++ b/Editor/Ndmf/Core/Cdw.cs
@@ -93,21 +93,81 @@ namespace KusakaFactory.Zatools.Ndmf.Core
             referencingRenderer.sharedMaterials = newMaterials;
         }
 
+        internal static void ProcessSeparate(SkinnedMeshRenderer referencingRenderer, Mesh modifyingMesh, FixedParameters parameters, Material wrapperMaterial)
+        {
+            if (!parameters.SeparateSmr || parameters.SourceMeshRenderer == null || parameters.SourceMeshRenderer.sharedMesh == null) return;
+
+            var sourceMesh = parameters.SourceMeshRenderer.sharedMesh;
+            var blendShapeAppliedVertices = MeshManipulation.ComputeBlendShapeAppliedVertices(sourceMesh, parameters.SourceMeshRenderer);
+
+            ImmutableArray<int> hullTriangles = ConvexHull.ComputeQuickHull3D(blendShapeAppliedVertices);
+            if (hullTriangles.Length < 12) return;
+
+            var sourceNormals = sourceMesh.normals;
+            var sourceTangents = sourceMesh.tangents;
+            var sourceBoneWeights = sourceMesh.boneWeights;
+            var sourceVertexCount = sourceMesh.vertexCount;
+            var validSourceTangents = sourceTangents.Length == sourceVertexCount;
+            var sourceHasBoneWeights = sourceBoneWeights != null && sourceBoneWeights.Length == sourceVertexCount;
+
+            var vertexMap = new Dictionary<int, int>();
+            var generatedVertices = new List<Vector3>();
+            var generatedNormals = new List<Vector3>();
+            var generatedUvs = new List<Vector2>();
+            var generatedTangents = validSourceTangents ? new List<Vector4>() : null;
+            var generatedBoneWeights = sourceHasBoneWeights ? new List<BoneWeight>() : null;
+            var generatedTriangles = new int[hullTriangles.Length];
+
+            for (int i = 0; i < hullTriangles.Length; i++)
+            {
+                var originalIndex = hullTriangles[i];
+                if (!vertexMap.TryGetValue(originalIndex, out var newIndex))
+                {
+                    newIndex = generatedVertices.Count;
+                    vertexMap.Add(originalIndex, newIndex);
+                    generatedVertices.Add(blendShapeAppliedVertices[originalIndex]);
+                    generatedNormals.Add(sourceNormals[originalIndex]);
+                    generatedUvs.Add(Vector2.zero);
+                    if (validSourceTangents) generatedTangents.Add(sourceTangents[originalIndex]);
+                    if (sourceHasBoneWeights) generatedBoneWeights.Add(sourceBoneWeights[originalIndex]);
+                }
+                generatedTriangles[i] = newIndex;
+            }
+
+            modifyingMesh.SetVertices(generatedVertices);
+            modifyingMesh.SetNormals(generatedNormals);
+            modifyingMesh.SetUVs(0, generatedUvs);
+            if (validSourceTangents) modifyingMesh.SetTangents(generatedTangents);
+            if (sourceHasBoneWeights) modifyingMesh.boneWeights = generatedBoneWeights.ToArray();
+            modifyingMesh.SetTriangles(generatedTriangles, 0);
+            modifyingMesh.bindposes = sourceMesh.bindposes;
+            modifyingMesh.RecalculateBounds();
+
+            referencingRenderer.sharedMaterials = new Material[] { wrapperMaterial };
+        }
+
         internal struct FixedParameters : IEquatable<FixedParameters>
         {
+            internal bool SeparateSmr;
+            internal SkinnedMeshRenderer SourceMeshRenderer;
+
             internal static FixedParameters FixFromComponent(ConvexDepthWrapper component)
             {
-                return new FixedParameters();
+                return new FixedParameters
+                {
+                    SeparateSmr = component.SourceMeshRenderer != null,
+                    SourceMeshRenderer = component.SourceMeshRenderer,
+                };
             }
 
             public bool Equals(FixedParameters other)
             {
-                return true;
+                return SeparateSmr == other.SeparateSmr && SourceMeshRenderer == other.SourceMeshRenderer;
             }
 
             public override bool Equals(object obj) => obj is FixedParameters && Equals((FixedParameters)obj);
 
-            public override int GetHashCode() => 0.GetHashCode();
+            public override int GetHashCode() => (SeparateSmr, SourceMeshRenderer).GetHashCode();
 
             public static bool operator ==(FixedParameters lhs, FixedParameters rhs) => lhs.Equals(rhs);
 

--- a/Editor/Ndmf/Inspector/CdwInspector.cs
+++ b/Editor/Ndmf/Inspector/CdwInspector.cs
@@ -1,6 +1,7 @@
-using UnityEngine.UIElements;
 using UnityEditor;
 using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
 using KusakaFactory.Zatools.Localization;
 using KusakaFactory.Zatools.Runtime;
 
@@ -17,7 +18,28 @@ namespace KusakaFactory.Zatools.Ndmf.Inspector
             ZatoolsLocalization.UILocalizer.ApplyLocalizationFor(inspector);
             inspector.Bind(serializedObject);
 
+            var sourceMeshRendererField = inspector.Q<ObjectField>("FieldSourceMeshRenderer");
+            var targetRenderer = (target as ConvexDepthWrapper)?.GetComponent<SkinnedMeshRenderer>();
+            UpdateSourceMeshRendererFieldVisibility(sourceMeshRendererField, targetRenderer);
+
+            var smrSerializedObject = new SerializedObject(targetRenderer);
+            var sharedMeshProperty = smrSerializedObject.FindProperty("m_Mesh");
+            if (sharedMeshProperty != null)
+            {
+                inspector.TrackPropertyValue(
+                    sharedMeshProperty,
+                    (_) => UpdateSourceMeshRendererFieldVisibility(sourceMeshRendererField, targetRenderer)
+                );
+            }
+
             return inspector;
+        }
+
+        private static void UpdateSourceMeshRendererFieldVisibility(ObjectField sourceMeshRendererField, SkinnedMeshRenderer targetRenderer)
+        {
+            sourceMeshRendererField.style.display = targetRenderer != null && targetRenderer.sharedMesh == null
+                ? DisplayStyle.Flex
+                : DisplayStyle.None;
         }
     }
 }

--- a/Editor/Ndmf/Inspector/CdwInspector.uxml
+++ b/Editor/Ndmf/Inspector/CdwInspector.uxml
@@ -2,6 +2,7 @@
     <Style src="project://database/Packages/org.kb10uy.zatools/Editor/Ndmf/Inspector/InspectorCommon.uss?fileID=7433441132597879392&amp;guid=c87deba29c7e8b643a69a6f5981f99ca&amp;type=3#InspectorCommon" />
     <ui:VisualElement style="flex-grow: 1;">
         <nadena.dev.ndmf.ui.LanguageSwitcher style="margin-top: 0; margin-right: 0; margin-bottom: 8px; margin-left: 4px;" />
+        <uie:ObjectField label="cdw.inspector.source" name="FieldSourceMeshRenderer" binding-path="SourceMeshRenderer" type="UnityEngine.SkinnedMeshRenderer, UnityEngine.CoreModule" class="ndmf-tr" />
         <ui:Foldout text="cdw.inspector.advanced" value="false" class="ndmf-tr">
             <uie:ObjectField label="cdw.inspector.material-override" name="FieldMaterialOverride" type="UnityEngine.Material, UnityEngine.CoreModule" binding-path="MaterialOverride" class="ndmf-tr" />
         </ui:Foldout>

--- a/Editor/Ndmf/Pass/CdwGenerating.cs
+++ b/Editor/Ndmf/Pass/CdwGenerating.cs
@@ -25,22 +25,37 @@ namespace KusakaFactory.Zatools.Ndmf.Pass
 
         private void ProcessFor(CdwComponent component, SkinnedMeshRenderer skinnedMeshRenderer, Transform avatarRoot)
         {
-            var originalMesh = skinnedMeshRenderer.sharedMesh;
-            if (originalMesh == null)
-            {
-                UnityObject.DestroyImmediate(component);
-                return;
-            }
-
+            var fixedParameters = Cdw.FixedParameters.FixFromComponent(component);
             var assigningMaterial = component.MaterialOverride != null ?
                 component.MaterialOverride :
                 AssetDatabase.LoadAssetAtPath<Material>(AssetDatabase.GUIDToAssetPath(WrapperMaterialGuid));
-            var fixedParameters = Cdw.FixedParameters.FixFromComponent(component);
-            var modifyingMesh = UnityObject.Instantiate(originalMesh);
-            Cdw.Process(skinnedMeshRenderer, modifyingMesh, fixedParameters, assigningMaterial);
 
-            skinnedMeshRenderer.sharedMesh = modifyingMesh;
-            ObjectRegistry.RegisterReplacedObject(originalMesh, modifyingMesh);
+            if (fixedParameters.SeparateSmr)
+            {
+                var generatedMesh = new Mesh { name = $"Convex Depth Wrapper for {fixedParameters.SourceMeshRenderer.name}" };
+                Cdw.ProcessSeparate(skinnedMeshRenderer, generatedMesh, fixedParameters, assigningMaterial);
+
+                skinnedMeshRenderer.sharedMesh = generatedMesh;
+                skinnedMeshRenderer.bones = fixedParameters.SourceMeshRenderer.bones;
+                skinnedMeshRenderer.rootBone = fixedParameters.SourceMeshRenderer.rootBone;
+                skinnedMeshRenderer.probeAnchor = fixedParameters.SourceMeshRenderer.probeAnchor;
+                skinnedMeshRenderer.localBounds = fixedParameters.SourceMeshRenderer.localBounds;
+            }
+            else
+            {
+                var originalMesh = skinnedMeshRenderer.sharedMesh;
+                if (originalMesh == null)
+                {
+                    UnityObject.DestroyImmediate(component);
+                    return;
+                }
+
+                var modifyingMesh = UnityObject.Instantiate(originalMesh);
+                Cdw.Process(skinnedMeshRenderer, modifyingMesh, fixedParameters, assigningMaterial);
+
+                skinnedMeshRenderer.sharedMesh = modifyingMesh;
+                ObjectRegistry.RegisterReplacedObject(originalMesh, modifyingMesh);
+            }
 
             UnityObject.DestroyImmediate(component);
         }

--- a/Editor/Ndmf/Preview/CdwPreview.cs
+++ b/Editor/Ndmf/Preview/CdwPreview.cs
@@ -25,6 +25,8 @@ namespace KusakaFactory.Zatools.Ndmf.Preview
 
         private Mesh _duplicatedMesh = null;
         private List<Material> _reassignedMaterials = null;
+        private bool _separateMesh = false;
+        private SkinnedMeshRenderer _separateSource = null;
 
         public override RenderAspects WhatChanged => RenderAspects.Mesh | RenderAspects.Material;
 
@@ -35,23 +37,36 @@ namespace KusakaFactory.Zatools.Ndmf.Preview
             ComputeContext context
         )
         {
-            if (proxyed == null || proxyed.sharedMesh == null) return default;
-
-            var duplicatedMesh = UnityObject.Instantiate(proxyed.sharedMesh);
-            duplicatedMesh.name = $"{duplicatedMesh.name} (Zatools modified)";
-
-            var observedParameters = components.Select((c) => context.Observe(
-                c,
-                Cdw.FixedParameters.FixFromComponent,
-                (op, np) => op == np
-            ));
-
             var wrapperMaterial = AssetDatabase.LoadAssetAtPath<Material>(AssetDatabase.GUIDToAssetPath(WrapperPreviewMaterialGuid));
-            foreach (var parameters in observedParameters) Cdw.Process(proxyed, duplicatedMesh, parameters, wrapperMaterial);
+            // ConvexDepthWrapper has DisallowMultipleComponent, a renderer will have at most one.
+            var observedParameter = context.Observe(components[0], Cdw.FixedParameters.FixFromComponent, (op, np) => op == np);
 
-            _duplicatedMesh = duplicatedMesh;
-            _reassignedMaterials = proxyed.sharedMaterials.ToList();
-            proxyed.sharedMesh = duplicatedMesh;
+            _separateMesh = observedParameter.SeparateSmr;
+            _separateSource = observedParameter.SourceMeshRenderer;
+
+            if (_separateMesh)
+            {
+                if (proxyed == null || proxyed.sharedMesh != null) return default;
+
+                var generatedMesh = new Mesh { name = $"Convex Depth Wrapper for Preview" };
+                Cdw.ProcessSeparate(proxyed, generatedMesh, observedParameter, wrapperMaterial);
+
+                _duplicatedMesh = generatedMesh;
+                _reassignedMaterials = proxyed.sharedMaterials.ToList();
+                proxyed.sharedMesh = generatedMesh;
+            }
+            else
+            {
+                if (proxyed == null || proxyed.sharedMesh == null) return default;
+
+                var duplicatedMesh = UnityObject.Instantiate(proxyed.sharedMesh);
+                duplicatedMesh.name = $"{duplicatedMesh.name} (Zatools modified)";
+                Cdw.Process(proxyed, duplicatedMesh, observedParameter, wrapperMaterial);
+
+                _duplicatedMesh = duplicatedMesh;
+                _reassignedMaterials = proxyed.sharedMaterials.ToList();
+                proxyed.sharedMesh = duplicatedMesh;
+            }
 
             return default;
         }
@@ -73,6 +88,14 @@ namespace KusakaFactory.Zatools.Ndmf.Preview
             {
                 proxyedSkinnedMeshRenderer.sharedMesh = _duplicatedMesh;
                 proxyedSkinnedMeshRenderer.sharedMaterials = _reassignedMaterials.ToArray();
+
+                if (_separateMesh)
+                {
+                    proxyedSkinnedMeshRenderer.bones = _separateSource.bones;
+                    proxyedSkinnedMeshRenderer.rootBone = _separateSource.rootBone;
+                    proxyedSkinnedMeshRenderer.probeAnchor = _separateSource.probeAnchor;
+                    proxyedSkinnedMeshRenderer.localBounds = _separateSource.localBounds;
+                }
             }
         }
 

--- a/Resources/Localizations/en-us.po
+++ b/Resources/Localizations/en-us.po
@@ -274,6 +274,9 @@ msgstr "Eyelash Cut Distance"
 msgid "edw.inspector.advanced"
 msgstr "Advanced"
 
+msgid "cdw.inspector.source"
+msgstr "Target Renderer"
+
 msgid "cdw.inspector.material-override"
 msgstr "Material to Assign"
 

--- a/Resources/Localizations/ja-jp.po
+++ b/Resources/Localizations/ja-jp.po
@@ -276,6 +276,9 @@ msgstr "まつ毛を無視する距離"
 msgid "edw.inspector.advanced"
 msgstr "上級者向け設定"
 
+msgid "cdw.inspector.source"
+msgstr "生成対象"
+
 msgid "cdw.inspector.material-override"
 msgstr "割り当てるマテリアル"
 

--- a/Runtime/ConvexDepthWrapper.cs
+++ b/Runtime/ConvexDepthWrapper.cs
@@ -6,8 +6,10 @@ namespace KusakaFactory.Zatools.Runtime
     [Icon("Packages/org.kb10uy.zatools/Resources/Icon.png")]
     [HelpURL("https://zatools.kb10uy.dev/ndmf-plugin/convex-depth-wrapper/")]
     [RequireComponent(typeof(SkinnedMeshRenderer))]
+    [DisallowMultipleComponent]
     public sealed class ConvexDepthWrapper : ZatoolsMeshEditingComponent
     {
         public Material MaterialOverride = null;
+        public SkinnedMeshRenderer SourceMeshRenderer = null;
     }
 }


### PR DESCRIPTION
* SkinnedMeshRenderer の sharedMesh が null のときは Separate Mesh モードとする
* 同時に一つしか付けられないようにする(考慮対象の単純化のため)