### PR TITLE
Remove InitializeOnLoad from ZatoolsLocalization

### DIFF
--- a/Editor/Localization/ZatoolsLocalization.cs
+++ b/Editor/Localization/ZatoolsLocalization.cs
@@ -9,7 +9,6 @@ using UnityEngine;
 
 namespace KusakaFactory.Zatools.Localization
 {
-    [InitializeOnLoad]
     internal static class ZatoolsLocalization
     {
         internal static readonly ImmutableList<string> SupportedLanguages = ImmutableList<string>.Empty


### PR DESCRIPTION
This got static initializer called before asset database initialization.