### PR TITLE
Fix override failure when overriding non-zero blendshapes

### DIFF
--- a/Editor/Foundation/MeshManipulation.cs
+++ b/Editor/Foundation/MeshManipulation.cs
@@ -44,6 +44,13 @@ namespace KusakaFactory.Zatools.Foundation
                 var i = mesh.GetBlendShapeIndex(name);
                 if (i == -1) continue;
                 if (mesh.GetBlendShapeFrameCount(i) != 1) continue;
+
+                if (applyingWeights.ContainsKey(i))
+                {
+                    applyingWeights[i] = value;
+                    continue;
+                }
+
                 if (Mathf.Abs(value) < epsilon) continue;
                 applyingWeights.Add(i, value);
             }


### PR DESCRIPTION
Thank you for implementing the blendshape override feature so quickly!

While using it, I noticed a small bug. When trying to override a blendshape that already has a modified (non-zero) value, the override fails. Instead of applying the new value, it throws an `ArgumentException`.

This PR fixes the issue so that blendshapes with existing non-zero values can now be overridden correctly.

#### Before
| `face_cheek_4` set to `0` | `face_cheek_4` set to `1` |
| -------------------------- | -------------------------- |
| <img width="1475" height="944" alt="螢幕擷取畫面 2026-05-25 160218" src="https://github.com/user-attachments/assets/b4a52a2f-8772-4b89-b32f-149e528c037a" /> | <img width="1475" height="934" alt="螢幕擷取畫面 2026-05-25 160236" src="https://github.com/user-attachments/assets/9d79bbf2-04b2-49dd-87fd-f11626e352a5" /> |
| blendshape override did not apply | throws `ArgumentException` |

#### After
| `face_cheek_4` set to `0` | `face_cheek_4` set to `1` |
| -------------------------- | -------------------------- |
| <img width="1468" height="937" alt="螢幕擷取畫面 2026-05-25 155340" src="https://github.com/user-attachments/assets/1d50dee2-563d-4821-827d-2a4d5f31c6fe" /> | <img width="1463" height="938" alt="螢幕擷取畫面 2026-05-25 155402" src="https://github.com/user-attachments/assets/adabe67c-feee-4ba7-bc19-e0dd72a16799" /> |
| blendshape override correctly applied  | blendshape override correctly applied  |