### PR TITLE
Fix EEPI dummy eye bone rotation

### DIFF
--- a/Editor/Ndmf/Pass/EepiTransforming.cs
+++ b/Editor/Ndmf/Pass/EepiTransforming.cs
@@ -151,7 +151,7 @@ namespace KusakaFactory.Zatools.Ndmf.Pass
             var dummyEye = new GameObject($"DummyEye_{side}");
             dummyEye.transform.SetParent(originalEye.parent, true);
             dummyEye.transform.position = originalEye.position;
-            dummyEye.transform.localRotation = Quaternion.identity;
+            dummyEye.transform.rotation = avatarRoot.rotation;
             originalEye.transform.SetParent(dummyEye.transform, true);
             return (dummyEye.transform, Quaternion.Inverse(originalEye.localRotation));
         }


### PR DESCRIPTION
たぶんこっちの方が正しい
Maya 製とかで元の eye bone が正面向きじゃない場合 GestureManager でバグるんだけどインゲームでは正しい見た目になるから大丈夫だと思う